### PR TITLE
Add jakarta validation in model domain

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/rules/HexagonalArchitectureTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/HexagonalArchitectureTest.java
@@ -35,6 +35,7 @@ public class HexagonalArchitectureTest implements ArchRuleTest  {
     private static String[] allowedPackageInDomain= {DOMAIN,
             "java..",
             "javax.validation..",
+            "jakarta.validation..",
             "org.slf4j..",
             "lombok..",
             "org.apache.commons.."};


### PR DESCRIPTION
## Summary

Add jakarta validation in model domain

## Details

javax is not used in last version.
